### PR TITLE
V1.0.3 to address #2 and code standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ https://github.com/rsl/stringex
 Add the following to your project.clj
 
 ```clojure
-[kibu/slugger "1.0.2"]
+[kibu/slugger "1.0.3"]
 ```
 
 Then you can use it:

--- a/README.md
+++ b/README.md
@@ -11,15 +11,17 @@ https://github.com/rsl/stringex
 Add the following to your project.clj
 
 ```clojure
-[slugger "1.0.1"]
+[kibu/slugger "1.0.2"]
 ```
 
 Then you can use it:
 
 ```clojure
 (use 'slugger.core)
+;; or in your `ns`:
+(require [slugger.core :refer [->slug]])
 
-(->slug "learn how to say 你好") 
+(->slug "learn how to say 你好")
 => "learn-how-to-say-ni-hao"
 
 (->slug "learn how to say 你好")

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject kibu/slugger "1.0.2"
+(defproject kibu/slugger "1.0.3"
   :description "Create good slugs from unicode data"
   :java-source-paths ["java"]
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -3,4 +3,4 @@
   :java-source-paths ["java"]
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.4.0"]])
+  :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/src/slugger/conversions.clj
+++ b/src/slugger/conversions.clj
@@ -2,7 +2,7 @@
   (:refer-clojure :exclude [replace])
   (:use [clojure.string :only [replace lower-case trim]])
   (:import [net.sf.junidecode Junidecode]))
-  
+
 (defn unidecode
   "Create 7-bit ascii version of unicode string."
   [text]
@@ -12,68 +12,66 @@
   "Convert html accent entities to correct 7bit ascii version"
   [text]
   (replace text #"&([A-Za-z])(grave|acute|circ|tilde|uml|ring|cedil|slash);" #(let [d (lower-case (second %))]
-                                                                                (cond 
+                                                                                (cond
                                                                                   (= d "o") "oe"
                                                                                   (= d "a") "aa"
                                                                                   (= d "u") "ue"
                                                                                   :else d))))
 
-(def ENTITY_RULES { "#822[01]" "\""
-                    "#821[67]" "'"
-                    "#8230" "..."
-                    "#8211" "-"
-                    "#8212" "--"
-                    "#215" "x"
-                    "gt" ">"
-                    "lt" "<"
-                    "(#8482|trade)" "(tm)"
-                    "(#174|reg)" "(r)"
-                    "(#169|copy)" "(c)"
-                    "(#38|amp)" "and"
-                    "nbsp" " "
-                    "(#162|cent)" " cent"
-                    "(#163|pound)" " pound"
-                    "(#188|frac14)" "one fourth"
-                    "(#189|frac12)" "half"
-                    "(#190|frac34)" "three fourths"
-                    "(#176|deg)" " degrees"})
+(def ENTITY_RULES {"#822[01]" "\""
+                   "#821[67]" "'"
+                   "#8230" "..."
+                   "#8211" "-"
+                   "#8212" "--"
+                   "#215" "x"
+                   "gt" ">"
+                   "lt" "<"
+                   "(#8482|trade)" "(tm)"
+                   "(#174|reg)" "(r)"
+                   "(#169|copy)" "(c)"
+                   "(#38|amp)" "and"
+                   "nbsp" " "
+                   "(#162|cent)" " cent"
+                   "(#163|pound)" " pound"
+                   "(#188|frac14)" "one fourth"
+                   "(#189|frac12)" "half"
+                   "(#190|frac34)" "three fourths"
+                   "(#176|deg)" " degrees"})
 
 (defn convert-misc-entities [text]
   (replace (reduce #(replace %1 (re-pattern (str "&" (key %2) ";")) (val %2)) text ENTITY_RULES) #"&[^;]+;" ""))
 
-(defn convert-rules 
+(defn convert-rules
   "Convert text by applying rules.
 
   Rules is a map consisting of a regex as the key and the string as the replacement value."
   [text rules]
   (reduce #(replace %1 (key %2) (val %2)) text rules))
 
-(def CURRENCY_RULES {
-        #"(\s|^)\$([\d|,| ]+)\.(\d+)(\s|$)" " $2 dollars $3 cents "
-        #"(\s|^)\€([\d|,| ]+)\.(\d+)(\s|$)" " $2 euros $3 cents "
-        #"(\s|^)£([\d|,| ]+)\.(\d+)(\s|$)"  " $2 pounds $3 pence "})
+(def CURRENCY_RULES {#"(\s|^)\$([\d|,| ]+)\.(\d+)(\s|$)" " $2 dollars $3 cents "
+                     #"(\s|^)\€([\d|,| ]+)\.(\d+)(\s|$)" " $2 euros $3 cents "
+                     #"(\s|^)£([\d|,| ]+)\.(\d+)(\s|$)"  " $2 pounds $3 pence "})
 
-(defn convert-currency 
+(defn convert-currency
   "Convert misc money values with cents to text."
   [text]
   (convert-rules text CURRENCY_RULES))
 
-(def NORMAL_RULES {
-        #"\s*&\s*" " and "
-        #"\s*#" " number "
-        #"\s*@\s*" " at "
-        #"(\S|^)\.(\S)" "$1 dot $2"
-        #"(\s|^)\$([\d|,| ]*)(\s|$)" " $2 dollars "
-        #"(\s|^)\€([\d|,| ]*)(\s|$)" " $2 euros "
-        #"(\s|^)£([\d|,| ]*)(\s|$)" " $2 pounds "
-        #"(\s|^)¥([\d|,| ]*)(\s|$)" " $2 yen "
-        #"\s*\+\s*" " plus "
-        #"\s*\*\s*" " star "
-        #"\s*%\s*" " percent "
-        #"\s*(\\|\/)\s*" " slash "
-        #"(\s*=\s*)" " equals "})
+(def NORMAL_RULES {#"\s*&\s*" " and "
+                   #"\s*#" " number "
+                   #"\s*@\s*" " at "
+                   #"(\S|^)\.(\S)" "$1 dot $2"
+                   #"(\s|^)\$([\d|,| ]*)(\s|$)" " $2 dollars "
+                   #"(\s|^)\€([\d|,| ]*)(\s|$)" " $2 euros "
+                   #"(\s|^)£([\d|,| ]*)(\s|$)" " $2 pounds "
+                   #"(\s|^)¥([\d|,| ]*)(\s|$)" " $2 yen "
+                   #"\s*\+\s*" " plus "
+                   #"\s*\*\s*" " star "
+                   #"\s*%\s*" " percent "
+                   #"\s*(\\|\/)\s*" " slash "
+                   #"(\s*=\s*)" " equals "})
 
-(defn convert-normal 
+(defn convert-normal
   "Convert various symbols to spelled out English"
   [text]
   (convert-rules text NORMAL_RULES))
@@ -83,5 +81,4 @@
       (convert-currency)
       (convert-normal)
       (replace #"(^|\w)'(\w|$)" "$1$2")
-      (replace (re-pattern "[.,:;()\\[\\]/\\\\?!^'\"_]") " ")
-      ))
+      (replace (re-pattern "[.,:;()\\[\\]/\\\\?!^'\"_]") " ")))

--- a/src/slugger/conversions.clj
+++ b/src/slugger/conversions.clj
@@ -18,7 +18,7 @@
                                                                                   (= d "u") "ue"
                                                                                   :else d))))
 
-(def ENTITY_RULES {"#822[01]" "\""
+(def entity-rules {"#822[01]" "\""
                    "#821[67]" "'"
                    "#8230" "..."
                    "#8211" "-"
@@ -39,7 +39,7 @@
                    "(#176|deg)" " degrees"})
 
 (defn convert-misc-entities [text]
-  (replace (reduce #(replace %1 (re-pattern (str "&" (key %2) ";")) (val %2)) text ENTITY_RULES) #"&[^;]+;" ""))
+  (replace (reduce #(replace %1 (re-pattern (str "&" (key %2) ";")) (val %2)) text entity-rules) #"&[^;]+;" ""))
 
 (defn convert-rules
   "Convert text by applying rules.
@@ -48,16 +48,16 @@
   [text rules]
   (reduce #(replace %1 (key %2) (val %2)) text rules))
 
-(def CURRENCY_RULES {#"(\s|^)\$([\d|,| ]+)\.(\d+)(\s|$)" " $2 dollars $3 cents "
+(def currency-rules {#"(\s|^)\$([\d|,| ]+)\.(\d+)(\s|$)" " $2 dollars $3 cents "
                      #"(\s|^)\€([\d|,| ]+)\.(\d+)(\s|$)" " $2 euros $3 cents "
                      #"(\s|^)£([\d|,| ]+)\.(\d+)(\s|$)"  " $2 pounds $3 pence "})
 
 (defn convert-currency
   "Convert misc money values with cents to text."
   [text]
-  (convert-rules text CURRENCY_RULES))
+  (convert-rules text currency-rules))
 
-(def NORMAL_RULES {#"\s*&\s*" " and "
+(def normal-rules {#"\s*&\s*" " and "
                    #"\s*#" " number "
                    #"\s*@\s*" " at "
                    #"(\S|^)\.(\S)" "$1 dot $2"
@@ -74,7 +74,7 @@
 (defn convert-normal
   "Convert various symbols to spelled out English"
   [text]
-  (convert-rules text NORMAL_RULES))
+  (convert-rules text normal-rules))
 
 (defn convert-misc-characters [text]
   (-> (replace text #"\.{3,}" " dot dot dot ")

--- a/src/slugger/conversions.clj
+++ b/src/slugger/conversions.clj
@@ -1,5 +1,4 @@
 (ns slugger.conversions
-  (:refer-clojure :exclude [replace])
   (:require [clojure.string :as s])
   (:import [net.sf.junidecode Junidecode]))
 

--- a/src/slugger/conversions.clj
+++ b/src/slugger/conversions.clj
@@ -1,6 +1,6 @@
 (ns slugger.conversions
   (:refer-clojure :exclude [replace])
-  (:use [clojure.string :only [replace lower-case trim]])
+  (:require [clojure.string :refer [replace lower-case trim]])
   (:import [net.sf.junidecode Junidecode]))
 
 (defn unidecode

--- a/src/slugger/conversions.clj
+++ b/src/slugger/conversions.clj
@@ -1,6 +1,6 @@
 (ns slugger.conversions
   (:refer-clojure :exclude [replace])
-  (:require [clojure.string :refer [replace lower-case trim]])
+  (:require [clojure.string :as s])
   (:import [net.sf.junidecode Junidecode]))
 
 (defn unidecode
@@ -11,12 +11,12 @@
 (defn convert-accented-entities
   "Convert html accent entities to correct 7bit ascii version"
   [text]
-  (replace text #"&([A-Za-z])(grave|acute|circ|tilde|uml|ring|cedil|slash);" #(let [d (lower-case (second %))]
-                                                                                (cond
-                                                                                  (= d "o") "oe"
-                                                                                  (= d "a") "aa"
-                                                                                  (= d "u") "ue"
-                                                                                  :else d))))
+  (s/replace text #"&([A-Za-z])(grave|acute|circ|tilde|uml|ring|cedil|slash);" #(let [d (s/lower-case (second %))]
+                                                                                  (cond
+                                                                                    (= d "o") "oe"
+                                                                                    (= d "a") "aa"
+                                                                                    (= d "u") "ue"
+                                                                                    :else d))))
 
 (def entity-rules {"#822[01]" "\""
                    "#821[67]" "'"
@@ -39,14 +39,14 @@
                    "(#176|deg)" " degrees"})
 
 (defn convert-misc-entities [text]
-  (replace (reduce #(replace %1 (re-pattern (str "&" (key %2) ";")) (val %2)) text entity-rules) #"&[^;]+;" ""))
+  (s/replace (reduce #(s/replace %1 (re-pattern (str "&" (key %2) ";")) (val %2)) text entity-rules) #"&[^;]+;" ""))
 
 (defn convert-rules
   "Convert text by applying rules.
 
-  Rules is a map consisting of a regex as the key and the string as the replacement value."
+  Rules is a map consisting of a regex as the key and the string as the s/replacement value."
   [text rules]
-  (reduce #(replace %1 (key %2) (val %2)) text rules))
+  (reduce #(s/replace %1 (key %2) (val %2)) text rules))
 
 (def currency-rules {#"(\s|^)\$([\d|,| ]+)\.(\d+)(\s|$)" " $2 dollars $3 cents "
                      #"(\s|^)\€([\d|,| ]+)\.(\d+)(\s|$)" " $2 euros $3 cents "
@@ -77,8 +77,8 @@
   (convert-rules text normal-rules))
 
 (defn convert-misc-characters [text]
-  (-> (replace text #"\.{3,}" " dot dot dot ")
+  (-> (s/replace text #"\.{3,}" " dot dot dot ")
       (convert-currency)
       (convert-normal)
-      (replace #"(^|\w)'(\w|$)" "$1$2")
-      (replace (re-pattern "[.,:;()\\[\\]/\\\\?!^'\"_]") " ")))
+      (s/replace #"(^|\w)'(\w|$)" "$1$2")
+      (s/replace (re-pattern "[.,:;()\\[\\]/\\\\?!^'\"_]") " ")))

--- a/src/slugger/core.clj
+++ b/src/slugger/core.clj
@@ -1,15 +1,15 @@
 (ns slugger.core
   (:refer-clojure :exclude [replace])
-  (:use [slugger.conversions]
-        [clojure.string :only [replace lower-case trim]]))
+  (:require [slugger.conversions :as c]
+            [clojure.string :refer [replace lower-case trim]]))
 
 (defn ->slug
   "Convert a UTF-8/16 string into a 7 bit ascii representation suitable for use as a slug in a url."
   [text]
-  (-> (unidecode text)
-      convert-accented-entities
-      convert-misc-entities
-      convert-misc-characters
+  (-> (c/unidecode text)
+      c/convert-accented-entities
+      c/convert-misc-entities
+      c/convert-misc-characters
       lower-case
       trim
       (replace #"\s+" "-")))

--- a/src/slugger/core.clj
+++ b/src/slugger/core.clj
@@ -1,7 +1,7 @@
 (ns slugger.core
   (:refer-clojure :exclude [replace])
   (:require [slugger.conversions :as c]
-            [clojure.string :refer [replace lower-case trim]]))
+            [clojure.string :as s]))
 
 (defn ->slug
   "Convert a UTF-8/16 string into a 7 bit ascii representation suitable for use as a slug in a url."
@@ -10,6 +10,6 @@
       c/convert-accented-entities
       c/convert-misc-entities
       c/convert-misc-characters
-      lower-case
-      trim
-      (replace #"\s+" "-")))
+      s/lower-case
+      s/trim
+      (s/replace #"\s+" "-")))

--- a/src/slugger/core.clj
+++ b/src/slugger/core.clj
@@ -7,9 +7,9 @@
   "Convert a UTF-8/16 string into a 7 bit ascii representation suitable for use as a slug in a url."
   [text]
   (-> (unidecode text)
-      (convert-accented-entities)
-      (convert-misc-entities)
-      (convert-misc-characters)
-      (lower-case)
-      (trim)
-      (replace  #"\s+" "-")))
+      convert-accented-entities
+      convert-misc-entities
+      convert-misc-characters
+      lower-case
+      trim
+      (replace #"\s+" "-")))

--- a/src/slugger/core.clj
+++ b/src/slugger/core.clj
@@ -1,5 +1,4 @@
 (ns slugger.core
-  (:refer-clojure :exclude [replace])
   (:require [slugger.conversions :as c]
             [clojure.string :as s]))
 

--- a/src/slugger/core.clj
+++ b/src/slugger/core.clj
@@ -6,10 +6,10 @@
   "Convert a UTF-8/16 string into a 7 bit ascii representation suitable for use as a slug in a url."
   [text]
   (-> text
-      c/unidecode
       c/convert-accented-entities
       c/convert-misc-entities
       c/convert-misc-characters
+      c/unidecode
       s/lower-case
       s/trim
       (s/replace #"\s+" "-")))

--- a/src/slugger/core.clj
+++ b/src/slugger/core.clj
@@ -5,7 +5,8 @@
 (defn ->slug
   "Convert a UTF-8/16 string into a 7 bit ascii representation suitable for use as a slug in a url."
   [text]
-  (-> (c/unidecode text)
+  (-> text
+      c/unidecode
       c/convert-accented-entities
       c/convert-misc-entities
       c/convert-misc-characters

--- a/test/slugger/core_test.clj
+++ b/test/slugger/core_test.clj
@@ -4,7 +4,17 @@
 
 (deftest simple-slug-test
   (testing "simple slugification"
-    (is (= (->slug " this string   should be simple enough") "this-string-should-be-simple-enough"))))
+    (is (= (->slug " this string   should be simple enough") "this-string-should-be-simple-enough"))
+    (is (= (->slug "WHAT ABOUT CAPITALS?") "what-about-capitals"))
+    (is (= (->slug ")(^!and special chars?") "and-special-chars"))))
+
+(deftest substitution-test
+  (testing "basic substitutions"
+    (is (= (->slug "*") "star"))
+    (is (= (->slug "@") "at"))
+    (is (= (->slug "#") "number"))
+    (is (= (->slug "%") "percent"))
+    (is (= (->slug "&") "and"))))
 
 (deftest kanji-test
   (testing "kanji slugs"

--- a/test/slugger/core_test.clj
+++ b/test/slugger/core_test.clj
@@ -2,11 +2,26 @@
   (:use clojure.test
         slugger.core))
 
-(deftest slug-tests
-  (is (= (->slug "learn how to say 你好")  "learn-how-to-say-ni-hao"))
-  (is (= (->slug " this string   should be simple enough")  "this-string-should-be-simple-enough"))
-  (is (= (->slug "Vi vil have mere &Oslash;l")  "vi-vil-have-mere-oel"))
-  (is (= (->slug "Vi vil have mere øl")  "vi-vil-have-mere-oel"))
-  (is (= (->slug "An idea worth $100")  "an-idea-worth-100-dollars"))
-  (is (= (->slug "An idea worth €100")  "an-idea-worth-100-euros"))
-  (is (= (->slug "my email address is pelle@picomoney.com")  "my-email-address-is-pelle-at-picomoney-dot-com")))
+(deftest simple-slug-test
+  (testing "simple slugification"
+    (is (= (->slug " this string   should be simple enough") "this-string-should-be-simple-enough"))))
+
+(deftest kanji-test
+  (testing "kanji slugs"
+    (is (= (->slug "learn how to say 你好") "learn-how-to-say-ni-hao"))))
+
+(deftest currency-test
+  (testing "currency slugs"
+    (is (= (->slug "An idea worth $100") "an-idea-worth-100-dollars"))
+    (is (= (->slug "An idea worth ¥100") "an-idea-worth-100-yen"))
+    (is (= (->slug "An idea worth £100") "an-idea-worth-100-pounds"))
+    (is (= (->slug "An idea worth €100") "an-idea-worth-100-euros"))))
+
+(deftest o-slash-test
+  (testing "Scandinavian o-slash"
+    (is (= (->slug "Vi vil have mere &Oslash;l")  "vi-vil-have-mere-oel"))
+    (is (= (->slug "Vi vil have mere øl")         "vi-vil-have-mere-oel"))))
+
+(deftest email-address-test
+  (testing "email address slugification"
+    (is (= (->slug "my email address is pelle@picomoney.com") "my-email-address-is-pelle-at-picomoney-dot-com"))))

--- a/test/slugger/core_test.clj
+++ b/test/slugger/core_test.clj
@@ -2,12 +2,11 @@
   (:use clojure.test
         slugger.core))
 
-
 (deftest slug-tests
   (is (= (->slug "learn how to say 你好")  "learn-how-to-say-ni-hao"))
   (is (= (->slug " this string   should be simple enough")  "this-string-should-be-simple-enough"))
   (is (= (->slug "Vi vil have mere &Oslash;l")  "vi-vil-have-mere-oel"))
   (is (= (->slug "Vi vil have mere øl")  "vi-vil-have-mere-oel"))
   (is (= (->slug "An idea worth $100")  "an-idea-worth-100-dollars"))
-  (is (= (->slug "my email address is pelle@picomoney.com")  "my-email-address-is-pelle-at-picomoney-dot-com"))
-  )
+  (is (= (->slug "An idea worth €100")  "an-idea-worth-100-euros"))
+  (is (= (->slug "my email address is pelle@picomoney.com")  "my-email-address-is-pelle-at-picomoney-dot-com")))


### PR DESCRIPTION
I've made changes across most of the code base, but most are small and broken up by commit.

 - updated us to the most recent version of Clojure
 - fixed currency issues in #2 and added tests for it
 - modernized namespace conventions
 - improved README to point to `kibu/` fork
 - split up tests so if one fails the tester knows *which* one
 - unilaterally and dictatorially decided to enforce lisp-case without democratic process
 - fixed a couple whitespace issues and weirdly formatted parens
 - bumped to version 1.0.3, which would be awesome if we could get deployed to clojars :) :) :)

:D Thanks! 